### PR TITLE
Bump versions of dependencies to avoid CVEs

### DIFF
--- a/pbf/core/build.gradle
+++ b/pbf/core/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
     api 'com.slimjars.trove4j:trove4j-object-int-hash-map:1.0.1'
 
-    api 'com.google.protobuf:protobuf-javalite:3.9.1'
+    api 'com.google.protobuf:protobuf-javalite:3.23.3'
 
     api 'net.jpountz.lz4:lz4:1.3.0'
 


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3510
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3509
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3171
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2976