### PR TITLE
Update lz4 to latest version

### DIFF
--- a/pbf/core/build.gradle
+++ b/pbf/core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     api 'com.google.protobuf:protobuf-javalite:3.23.4'
 
-    api 'net.jpountz.lz4:lz4:1.3.0'
+    api 'org.lz4:lz4-java:1.8.0'
 
     api 'org.slf4j:slf4j-api:1.7.36'
 


### PR DESCRIPTION
Based on lz4 1.4.0 documentation: https://github.com/lz4/lz4-java/blob/master/CHANGES.md
groupId and artifactId have been changed from net.jpountz.lz4 and lz4 to org.lz4 and lz4-java, respectively.

IT makes osm4j includes a library that clashes with other libraries such as kafka that use a newer version
