### PR TITLE
Bumb versions of Github actions to enable CI on PRs

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '17'

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -16,6 +16,6 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
     - name: Run Gradle tests
       run: ./gradlew check --info --stacktrace

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Java
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
I noticed that the CI was not running on the latest PRs. This updates the Github actions so it should work again.