### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 15
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
This change adds a Dependabot configuration file to keep this project up to date with less manual work.
* This should be merged after #20 so CI runs on the first PRs Dependabot creates
* You still might need to enable "Dependabot version updates" under "Advanced Security" in the [repository settings](https://github.com/topobyte/osm4j/settings/security_analysis) after merging this PR